### PR TITLE
Do not raise on unsuccessful cast

### DIFF
--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -90,11 +90,9 @@ if Code.ensure_loaded?(Ecto.Type) do
     end
 
     defp do_cast(geom) when is_binary(geom) do
-      with {:ok, geom} <- Geo.PostGIS.Config.json_library().decode(geom),
-           {:ok, result} <- Geo.JSON.decode(geom) do
-        {:ok, result}
-      else
-        _ -> :error
+      case Geo.PostGIS.Config.json_library().decode(geom) do
+        {:ok, geom} when is_map(geom) -> do_cast(geom)
+        {:error, reason} -> {:error, [message: "failed to decode JSON", reason: reason]}
       end
     end
 

--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -90,7 +90,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     end
 
     defp do_cast(geom) when is_binary(geom) do
-      with {:ok, geom} <- Geo.PostGIS.Config.json_library().decode(),
+      with {:ok, geom} <- Geo.PostGIS.Config.json_library().decode(geom),
            {:ok, result} <- Geo.JSON.decode(geom) do
         {:ok, result}
       else

--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -99,7 +99,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     defp do_cast(geom) do
       case Geo.JSON.decode(geom) do
         {:ok, result} -> {:ok, result}
-        {:error, _} -> :error
+        {:error, reason} -> {:error, [message: "failed to decode GeoJSON", reason: reason]}
       end
     end
 

--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -89,6 +89,8 @@ if Code.ensure_loaded?(Ecto.Type) do
       do_cast(geom)
     end
 
+    def cast(_), do: :error
+
     defp do_cast(geom) when is_binary(geom) do
       case Geo.PostGIS.Config.json_library().decode(geom) do
         {:ok, geom} when is_map(geom) -> do_cast(geom)
@@ -102,8 +104,6 @@ if Code.ensure_loaded?(Ecto.Type) do
         {:error, reason} -> {:error, [message: "failed to decode GeoJSON", reason: reason]}
       end
     end
-
-    def cast(_), do: :error
 
     def embed_as(_), do: :self
 


### PR DESCRIPTION
Currently when there's invalid value(such as empty string) given to the `Geo.PostGIS.Geometry.case`  it raises.

It's not a perfect solution if we want to use this function when parsing data that comes from outside of the system, like GraphQL request. 

To make it more friendly to use I've made so that on unsuccessful cast returns `:error` instead of raising.