### PR TITLE
Add GitHub Actions CI and bump minimum Elixir version to v1.11

### DIFF
--- a/.github/actions/elixir-setup/action.yml
+++ b/.github/actions/elixir-setup/action.yml
@@ -1,0 +1,141 @@
+name: Setup Elixir Project
+description: Checks out the code, configures Elixir, fetches dependencies, and manages build caching.
+inputs:
+  elixir-version:
+    required: true
+    type: string
+    description: Elixir version to set up
+  otp-version:
+    required: true
+    type: string
+    description: OTP version to set up
+  #################################################################
+  # Everything below this line is optional.
+  #
+  # It's designed to make compiling a reasonably standard Elixir
+  # codebase "just work," though there may be speed gains to be had
+  # by tweaking these flags.
+  #################################################################
+  build-deps:
+    required: false
+    type: boolean
+    default: true
+    description: True if we should compile dependencies
+  build-app:
+    required: false
+    type: boolean
+    default: true
+    description: True if we should compile the application itself
+  build-flags:
+    required: false
+    type: string
+    default: '--all-warnings'
+    description: Flags to pass to mix compile
+  install-rebar:
+    required: false
+    type: boolean
+    default: true
+    description: By default, we will install Rebar (mix local.rebar --force).
+  install-hex:
+    required: false
+    type: boolean
+    default: true
+    description: By default, we will install Hex (mix local.hex --force).
+  cache-key:
+    required: false
+    type: string
+    default: 'v1'
+    description: If you need to reset the cache for some reason, you can change this key.
+outputs:
+  otp-version:
+    description: "Exact OTP version selected by the BEAM setup step"
+    value: ${{ steps.beam.outputs.otp-version }}
+  elixir-version:
+    description: "Exact Elixir version selected by the BEAM setup step"
+    value: ${{ steps.beam.outputs.elixir-version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Setup elixir
+      uses: erlef/setup-beam@v1.15.4
+      id: beam
+      with:
+        elixir-version: ${{ inputs.elixir-version }}
+        otp-version: ${{ inputs.otp-version }}
+
+    - name: Get deps cache
+      uses: actions/cache@v2
+      with:
+        path: deps/
+        key: deps-${{ inputs.cache-key }}-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          deps-${{ inputs.cache-key }}-${{ runner.os }}-
+
+    - name: Get build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: _build/${{env.MIX_ENV}}/
+        key: build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-
+
+    - name: Get Hex cache
+      uses: actions/cache@v2
+      id: hex-cache
+      with:
+        path: ~/.hex
+        key: hex-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          hex-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-
+
+    - name: Get Mix cache
+      uses: actions/cache@v2
+      id: mix-cache
+      with:
+        path: ${{ env.MIX_HOME || '~/.mix' }}
+        key: mix-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          mix-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-
+
+    # In my experience, I have issues with incremental builds maybe 1 in 100
+    # times that are fixed by doing a full recompile.
+    # In order to not waste dev time on such trivial issues (while also reaping
+    # the time savings of incremental builds for *most* day-to-day development),
+    # I force a full recompile only on builds that we retry.
+    - name: Clean to rule out incremental build as a source of flakiness
+      if: github.run_attempt != '1'
+      run: | 
+        mix deps.clean --all
+        mix clean
+      shell: sh
+
+    - name: Install Rebar
+      run: mix local.rebar --force --if-missing
+      shell: sh
+      if: inputs.install-rebar == 'true'
+
+    - name: Install Hex
+      run: mix local.hex --force --if-missing
+      shell: sh
+      if: inputs.install-hex == 'true'
+
+    - name: Install Dependencies
+      run: mix deps.get
+      shell: sh
+
+    # Normally we'd use `mix deps.compile` here, however that incurs a large
+    # performance penalty when the dependencies are already fully compiled:
+    # https://elixirforum.com/t/github-action-cache-elixir-always-recompiles-dependencies-elixir-1-13-3/45994/12
+    #
+    # Accoring to Jose Valim at the above link `mix loadpaths` will check and
+    # compile missing dependencies
+    - name: Compile Dependencies
+      run: mix loadpaths
+      shell: sh
+      if: inputs.build-deps == 'true'
+
+    - name: Compile Application
+      run: mix compile ${{ inputs.build-flags }}
+      shell: sh
+      if: inputs.build-app == 'true'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,24 +7,4 @@ updates:
     time: "11:00"
   open-pull-requests-limit: 10
   assignees:
-  - bryanjos
-  ignore:
-  - dependency-name: ecto_sql
-    versions:
-    - 3.5.4
-    - 3.6.0
-  - dependency-name: postgrex
-    versions:
-    - 0.15.8
-  - dependency-name: ex_doc
-    versions:
-    - 0.23.0
-    - 0.24.0
-    - 0.24.1
-    - 0.24.2
-  - dependency-name: geo
-    versions:
-    - 3.3.5
-  - dependency-name: jason
-    versions:
-    - 1.2.2
+  - s3cur3

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -1,0 +1,79 @@
+name: Elixir Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    name: Elixir Unit Tests
+    runs-on: ubuntu-20.04
+    env:
+      MIX_ENV: test
+      PGPASSWORD: postgres
+    strategy:
+      matrix:
+        elixir: ["1.11.4", "1.12.3", "1.13.4", "1.14.4", "1.15.5"]
+        otp: ["22.3", "23.3.4", "24.3.4", "25.3.2", "26.0.2"]
+        exclude:
+          # Elixir 1.11 doesn't support the latest OTP
+          - elixir: "1.11.4"
+            otp: "25.3.2"
+          - elixir: "1.11.4"
+            otp: "26.0.2"
+          # Elixir 1.12 doesn't support the latest OTP
+          - elixir: "1.12.3"
+            otp: "25.3.2"
+          - elixir: "1.12.3"
+            otp: "26.0.2"
+          # Elixir 1.13 doesn't support the latest OTP
+          - elixir: "1.13.4"
+            otp: "26.0.2"
+          # Elixir 1.14 requires at least OTP 23
+          - elixir: "1.14.4"
+            otp: "22.3"
+          # Elixir 1.15 requires at least OTP 24
+          - elixir: "1.15.5"
+            otp: "22.3"
+          - elixir: "1.15.5"
+            otp: "23.3.4"
+
+    services:
+      db:
+        image: postgis/postgis:13-3.1
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: geo_postgrex_test
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Elixir Project
+        uses: ./.github/actions/elixir-setup
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+          build-app: false
+
+      - name: Compile with warnings as errors
+        if: ${{ matrix.elixir != '1.11.4' }} 
+        run: mix compile --warnings-as-errors
+
+      - name: Run tests with warnings as errors
+        if: ${{ matrix.elixir != '1.11.4' }} 
+        run: mix test --warnings-as-errors
+
+      - name: Run tests
+        if: ${{ matrix.elixir == '1.11.4' }}
+        run: mix test

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -1,0 +1,45 @@
+name: Elixir Quality Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  quality_checks:
+    name: Elixir Quality Checks
+    runs-on: ubuntu-latest
+    env:
+      # In MIX_ENV=test, `$ mix xref graph` shows us a whole bunch of
+      # test stuff that isn't really relevant.
+      # The other checks don't really care what environment they run in.
+      MIX_ENV: dev
+      elixir: "1.15.4"
+      otp: "26.0.2"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Elixir Project
+        uses: ./.github/actions/elixir-setup
+        with:
+          elixir-version: ${{ env.elixir }}
+          otp-version: ${{ env.otp }}
+          build-app: false
+
+      - name: Check for unused deps
+        run: mix deps.unlock --check-unused
+
+      - name: Check code formatting
+        run: mix format --check-formatted
+        # We run all checks here even if others failed so that
+        # we give devs as much feedback as possible & save some time.
+        if: always()
+
+      - name: Check for compile-time dependencies between modules
+        run: mix xref graph --label compile-connected --fail-above 0
+        if: always()

--- a/.github/workflows/elixir-retired-packages-check.yml
+++ b/.github/workflows/elixir-retired-packages-check.yml
@@ -1,0 +1,32 @@
+name: Elixir Retired Packages Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  retired_packages:
+    name: Elixir Retired Packages Check
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: dev
+      elixir: "1.15.4"
+      otp: "26.0.2"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Elixir Project
+        uses: ./.github/actions/elixir-setup
+        with:
+          elixir-version: ${{ env.elixir }}
+          otp-version: ${{ env.otp }}
+          build-app: false
+
+      - name: Check for retired/abandoned deps
+        run: mix hex.audit

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ geo_postgis-*.tar
 
 # Emacs project file
 .projectile
+
+.lexical/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## vNext
+
+- The minimum Elixir version is now 1.11, matching the latest `postgrex`
+
 ## [3.4.3] - 2023-06-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoPostGIS
 
-[![Build & Test Status](https://github.com/felt/geo_postgis/actions/workflows/elixir-build-and-test.yml/badge.svg)](https://github.com/felt/geo_postgis/actions/workflows/elixir-build-and-test.yml)
+[![Build & Test Status](https://github.com/felt/geo_postgis/actions/workflows/elixir-build-and-test.yml/badge.svg?branch=master)](https://github.com/felt/geo_postgis/actions/workflows/elixir-build-and-test.yml)
 [![Module Version](https://img.shields.io/hexpm/v/geo_postgis.svg)](https://hex.pm/packages/geo_postgis)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/geo_postgis/)
 [![Total Download](https://img.shields.io/hexpm/dt/geo_postgis.svg)](https://hex.pm/packages/geo_postgis)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoPostGIS
 
-[![Build Status](https://travis-ci.org/bryanjos/geo_postgis.svg?branch=master)](https://travis-ci.org/bryanjos/geo_postgis)
+[![Build & Test Status](https://github.com/felt/geo_postgis/actions/workflows/elixir-build-and-test.yml/badge.svg)](https://github.com/felt/geo_postgis/actions/workflows/elixir-build-and-test.yml)
 [![Module Version](https://img.shields.io/hexpm/v/geo_postgis.svg)](https://hex.pm/packages/geo_postgis)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/geo_postgis/)
 [![Total Download](https://img.shields.io/hexpm/dt/geo_postgis.svg)](https://hex.pm/packages/geo_postgis)

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,4 @@
 # and its dependencies with the aid of the Mix.Config module.
 import Config
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
 defmodule GeoPostgis.Mixfile do
   use Mix.Project
 
-  @source_url "https://github.com/bryanjos/geo_postgis"
+  @source_url "https://github.com/felt/geo_postgis"
   @version "3.4.3"
 
   def project do
     [
       app: :geo_postgis,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       name: "GeoPostGIS",
       deps: deps(),
@@ -40,7 +40,7 @@ defmodule GeoPostgis.Mixfile do
     [
       description: "PostGIS extension for Postgrex.",
       files: ["lib", "mix.exs", "README.md", "CHANGELOG.md"],
-      maintainers: ["Bryan Joseph"],
+      maintainers: ["Tyler Young", "Bryan Joseph"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
 %{
-  "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
   "db_connection": {:hex, :db_connection, "2.5.0", "bb6d4f30d35ded97b29fe80d8bd6f928a1912ca1ff110831edcd238a1973652c", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "c92d5ba26cd69ead1ff7582dbb860adeedfff39774105a4f1c92cbb654b55aa2"},
   "decimal": {:hex, :decimal, "2.1.1", "5611dca5d4b2c3dd497dec8f68751f1f1a54755e8ed2a966c2633cf885973ad6", [:mix], [], "hexpm", "53cfe5f497ed0e7771ae1a475575603d77425099ba5faef9394932b35020ffcc"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.32", "fa739a0ecfa34493de19426681b23f6814573faee95dfd4b4aafe15a7b5b32c6", [:mix], [], "hexpm", "b8b0dd77d60373e77a3d7e8afa598f325e49e8663a51bcc2b88ef41838cca755"},


### PR DESCRIPTION
Adds GitHub Actions for:

- build & test for all combinations of Elixir 1.11, 1.12, 1.13, 1.14, and 1.15, plus OTP 22, 23, 24, 25, and 26
- basic code quality checks (and a formatting fix and unused dependency removal to match)
- checking for retired Hex dependencies

Also updates the maintainers list and URL to reflect the new Felt org.

The big change here is that in the course of setting up the test matrix, I discovered the project won't even compile on Elixir 1.10, so the next version will show that as a breaking change (even though it actually happened in the past due to the dependency on postgrex.)