### PR TITLE
Type Geometry

### DIFF
--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -57,6 +57,22 @@ if Code.ensure_loaded?(Ecto.Type) do
       GeometryCollection
     ]
 
+    @type t ::
+            Point.t()
+            | PointZ.t()
+            | PointM.t()
+            | PointZM.t()
+            | LineString.t()
+            | LineStringZ.t()
+            | Polygon.t()
+            | PolygonZ.t()
+            | MultiPoint.t()
+            | MultiPointZ.t()
+            | MultiLineString.t()
+            | MultiLineStringZ.t()
+            | MultiPolygon.t()
+            | MultiPolygonZ.t()
+
     if macro_exported?(Ecto.Type, :__using__, 1) do
       use Ecto.Type
     else

--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -57,21 +57,7 @@ if Code.ensure_loaded?(Ecto.Type) do
       GeometryCollection
     ]
 
-    @type t ::
-            Point.t()
-            | PointZ.t()
-            | PointM.t()
-            | PointZM.t()
-            | LineString.t()
-            | LineStringZ.t()
-            | Polygon.t()
-            | PolygonZ.t()
-            | MultiPoint.t()
-            | MultiPointZ.t()
-            | MultiLineString.t()
-            | MultiLineStringZ.t()
-            | MultiPolygon.t()
-            | MultiPolygonZ.t()
+    @type t :: Geo.geometry()
 
     if macro_exported?(Ecto.Type, :__using__, 1) do
       use Ecto.Type

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -37,8 +37,7 @@ defmodule Geo.Ecto.Test do
   setup _ do
     {:ok, pid} = Postgrex.start_link(Geo.Test.Helper.opts())
 
-    {:ok, _} =
-      Postgrex.query(pid, "CREATE EXTENSION IF NOT EXISTS postgis", [])
+    {:ok, _} = Postgrex.query(pid, "CREATE EXTENSION IF NOT EXISTS postgis", [])
 
     {:ok, _} =
       Postgrex.query(pid, "DROP TABLE IF EXISTS locations, geographies, location_multi", [])


### PR DESCRIPTION
When using with [`TypedEctoSchema`](https://hexdocs.pm/typed_ecto_schema/TypedEctoSchema.html)

```elixir
defmodule MyApp.Service do
  use TypedEctoSchema

  typed_schema "services" do
    field :location, Geo.PostGIS.Geometry
    field :foo, :integer
  end
end
```
it tries to create a type for the schema as
```elixir
  @type t() :: %__MODULE__{
          location: Geo.PostGIS.Geometry.t()
          foo: integer()
          ...
        }
```
And Geometry.t() is not declared.

Current workaround for us is declaring that type in our application
```elixir
defmodule MyApp.Geo.PostGIS.Geometry do
  @type t ::
            Geo.Point.t()
            | Geo.PointZ.t()
            ...
end
```
and refer to it in schema
```elixir
typed_schema "services" do
  field(:location, Geo.PostGIS.Geometry) :: MyApp.Geo.PostGIS.Geometry.t()
  field :foo, :integer
end
```