### PR TITLE
Bump version to 3.6.0 in preparation for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2024-03-11
+
+### New feature
+
+* Add support for LineStringZM, with thanks to new contributor @versilov (#160)
+
+### Fixes and updates
+
+* Silence compile warning by updating `geo` from 3.5.1 to 3.6.0
+* Misc. dependency updates (ex_doc, ecto, ecto_sql, and postgrex)
+
 ## [3.5.0] - 2023-09-22
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:geo_postgis, "~> 3.5"}
+    {:geo_postgis, "~> 3.6"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GeoPostgis.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/felt/geo_postgis"
-  @version "3.5.0"
+  @version "3.6.0"
 
   def project do
     [


### PR DESCRIPTION
Updates the docs for a release that takes one minor feature and a few dependency updates.