### PR TITLE
Add support for Elixir 1.16 in CI

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -80,5 +80,4 @@ jobs:
         run: mix test --warnings-as-errors
 
       - name: Run tests
-        if: ${{ matrix.elixir == '1.11.4' }}
         run: mix test

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -17,35 +17,53 @@ jobs:
       PGPASSWORD: postgres
     strategy:
       matrix:
-        elixir: ["1.11.4", "1.12.3", "1.13.4", "1.14.4", "1.15.5", "1.16.2"]
-        otp: ["22.3", "23.3.4", "24.3.4", "25.3.2", "26.1.2"]
-        exclude:
-          # Elixir 1.11 doesn't support the latest OTP
-          - elixir: "1.11.4"
-            otp: "25.3.2"
-          - elixir: "1.11.4"
-            otp: "26.1.2"
-          # Elixir 1.12 doesn't support the latest OTP
-          - elixir: "1.12.3"
-            otp: "25.3.2"
-          - elixir: "1.12.3"
-            otp: "26.1.2"
-          # Elixir 1.13 doesn't support the latest OTP
-          - elixir: "1.13.4"
-            otp: "26.1.2"
-          # Elixir 1.14 requires at least OTP 23
-          - elixir: "1.14.4"
-            otp: "22.3"
+        include:
+          # Elixir 1.11 doesn't support OTP 25+
+          - elixir: '1.11.4'
+            otp: '22.3'
+          - elixir: '1.11.4'
+            otp: '23.3.4'
+          - elixir: '1.11.4'
+            otp: '24.3.4'
+          # Elixir 1.12 doesn't support OTP 25+
+          - elixir: '1.12.3'
+            otp: '22.3'
+          - elixir: '1.12.3'
+            otp: '23.3.4'
+          - elixir: '1.12.3'
+            otp: '24.3.4'
+          # Elixir 1.13 doesn't support OTP 26+
+          - elixir: '1.13.4'
+            otp: '22.3'
+          - elixir: '1.13.4'
+            otp: '23.3.4'
+          - elixir: '1.13.4'
+            otp: '24.3.4'
+          - elixir: '1.13.4'
+            otp: '25.3.2'
+        # Elixir 1.14 requires at least OTP 23
+          - elixir: '1.14.4'
+            otp: '23.3.4'
+          - elixir: '1.14.4'
+            otp: '24.3.4'
+          - elixir: '1.14.4'
+            otp: '25.3.2'
+          - elixir: '1.14.4'
+            otp: '26.2.5'
           # Elixir 1.15 requires at least OTP 24
-          - elixir: "1.15.5"
-            otp: "22.3"
-          - elixir: "1.15.5"
-            otp: "23.3.4"
+          - elixir: '1.15.5'
+            otp: '24.3.4'
+          - elixir: '1.15.5'
+            otp: '25.3.2'
+          - elixir: '1.15.5'
+            otp: '26.2.5'
           # Elixir 1.16 requires at least OTP 24
-          - elixir: "1.16.2"
-            otp: "22.3"
-          - elixir: "1.16.2"
-            otp: "23.3.4"
+          - elixir: '1.16.2'
+            otp: '24.3.4'
+          - elixir: '1.16.2'
+            otp: '25.3.2'
+          - elixir: '1.16.2'
+            otp: '26.2.5'
 
     services:
       db:

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -17,22 +17,22 @@ jobs:
       PGPASSWORD: postgres
     strategy:
       matrix:
-        elixir: ["1.11.4", "1.12.3", "1.13.4", "1.14.4", "1.15.5"]
-        otp: ["22.3", "23.3.4", "24.3.4", "25.3.2", "26.0.2"]
+        elixir: ["1.11.4", "1.12.3", "1.13.4", "1.14.4", "1.15.5", "1.16.2"]
+        otp: ["22.3", "23.3.4", "24.3.4", "25.3.2", "26.1.2"]
         exclude:
           # Elixir 1.11 doesn't support the latest OTP
           - elixir: "1.11.4"
             otp: "25.3.2"
           - elixir: "1.11.4"
-            otp: "26.0.2"
+            otp: "26.1.2"
           # Elixir 1.12 doesn't support the latest OTP
           - elixir: "1.12.3"
             otp: "25.3.2"
           - elixir: "1.12.3"
-            otp: "26.0.2"
+            otp: "26.1.2"
           # Elixir 1.13 doesn't support the latest OTP
           - elixir: "1.13.4"
-            otp: "26.0.2"
+            otp: "26.1.2"
           # Elixir 1.14 requires at least OTP 23
           - elixir: "1.14.4"
             otp: "22.3"
@@ -40,6 +40,11 @@ jobs:
           - elixir: "1.15.5"
             otp: "22.3"
           - elixir: "1.15.5"
+            otp: "23.3.4"
+          # Elixir 1.16 requires at least OTP 24
+          - elixir: "1.16.2"
+            otp: "22.3"
+          - elixir: "1.16.2"
             otp: "23.3.4"
 
     services:

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -17,8 +17,8 @@ jobs:
       # test stuff that isn't really relevant.
       # The other checks don't really care what environment they run in.
       MIX_ENV: dev
-      elixir: "1.15.4"
-      otp: "26.0.2"
+      elixir: "1.16.2"
+      otp: "26.1.2"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-retired-packages-check.yml
+++ b/.github/workflows/elixir-retired-packages-check.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MIX_ENV: dev
-      elixir: "1.15.4"
-      otp: "26.0.2"
+      elixir: "1.16.2"
+      otp: "26.1.2"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
I figured it'd be good to have 1.16 tested in CI the same way we do other versions.