### PR TITLE
Upgrade actions to use cache v4

### DIFF
--- a/.github/actions/elixir-setup/action.yml
+++ b/.github/actions/elixir-setup/action.yml
@@ -64,7 +64,7 @@ runs:
         otp-version: ${{ inputs.otp-version }}
 
     - name: Get deps cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps/
         key: deps-${{ inputs.cache-key }}-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
@@ -72,7 +72,7 @@ runs:
           deps-${{ inputs.cache-key }}-${{ runner.os }}-
 
     - name: Get build cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: build-cache
       with:
         path: _build/${{env.MIX_ENV}}/
@@ -81,7 +81,7 @@ runs:
           build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-
 
     - name: Get Hex cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: hex-cache
       with:
         path: ~/.hex
@@ -90,7 +90,7 @@ runs:
           hex-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-
 
     - name: Get Mix cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: mix-cache
       with:
         path: ${{ env.MIX_HOME || '~/.mix' }}

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Elixir Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       MIX_ENV: test
       PGPASSWORD: postgres

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Elixir Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MIX_ENV: test
       PGPASSWORD: postgres

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   quality_checks:
     name: Elixir Quality Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       # In MIX_ENV=test, `$ mix xref graph` shows us a whole bunch of
       # test stuff that isn't really relevant.

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   quality_checks:
     name: Elixir Quality Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # In MIX_ENV=test, `$ mix xref graph` shows us a whole bunch of
       # test stuff that isn't really relevant.

--- a/.github/workflows/elixir-retired-packages-check.yml
+++ b/.github/workflows/elixir-retired-packages-check.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   retired_packages:
     name: Elixir Retired Packages Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       MIX_ENV: dev
       elixir: "1.16.2"

--- a/.github/workflows/elixir-retired-packages-check.yml
+++ b/.github/workflows/elixir-retired-packages-check.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   retired_packages:
     name: Elixir Retired Packages Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       MIX_ENV: dev
       elixir: "1.16.2"


### PR DESCRIPTION
https://github.com/actions/cache/discussions/1510

GitHub actions/cache@v2 is deprecated and no longer functions. Updated version so checks can run!