### PR TITLE
Use built in JSON encoder/decoder by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Make sure PostGIS extension to your database is installed. More information [her
 ```elixir
 # When a binary is passed to `Geo.PostGIS.Geometry.cast/1` implementation of
 # `Ecto.Type.cast/1`, it is assumed to be a GeoJSON string. When this happens,
-# geo_postgis will use Poison, by default, to convert the binary to a map and
+# geo_postgis will use JSON, by default, to convert the binary to a map and
 # then convert that map to one of the Geo structs. If in these cases you would
 # like to use a different JSON parser, you can set the config below.
 

--- a/lib/geo_postgis/config.ex
+++ b/lib/geo_postgis/config.ex
@@ -1,5 +1,11 @@
 defmodule Geo.PostGIS.Config do
+  if Code.ensure_loaded?(JSON) do
+    @default_json_library JSON
+  else
+    @default_json_library Poison
+  end
+
   def json_library do
-    Application.get_env(:geo_postgis, :json_library, Poison)
+    Application.get_env(:geo_postgis, :json_library, @default_json_library)
   end
 end


### PR DESCRIPTION
Unless we are trying to pretty print stuff this is a better choice if you are on elixir 1.18+