### PR TITLE
Add atom-keyed cast/1 function clauses

### DIFF
--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -93,6 +93,20 @@ if Code.ensure_loaded?(Ecto.Type) do
       do_cast(geom)
     end
 
+    def cast(%{type: type, coordinates: _} = geom) when type in @types do
+      case Geo.PostGIS.Config.json_library().encode(geom) do
+        {:ok, geom} when is_binary(geom) -> do_cast(geom)
+        {:error, reason} -> {:error, [message: "failed to encode JSON", reason: reason]}
+      end
+    end
+
+    def cast(%{type: "GeometryCollection", geometries: _} = geom) do
+      case Geo.PostGIS.Config.json_library().encode(geom) do
+        {:ok, geom} when is_binary(geom) -> do_cast(geom)
+        {:error, reason} -> {:error, [message: "failed to encode JSON", reason: reason]}
+      end
+    end
+
     def cast(geom) when is_binary(geom) do
       do_cast(geom)
     end

--- a/test/geometry_test.exs
+++ b/test/geometry_test.exs
@@ -1,0 +1,36 @@
+defmodule Geo.PostGIS.GeometryCastTest do
+  use ExUnit.Case, async: true
+  alias Geo.PostGIS.Geometry
+
+  describe "Geometry.cast/1" do
+    test "cast from map with key => value syntax" do
+      point_map = %{
+        "type" => "Point",
+        "coordinates" => [30.0, -90.0],
+        "crs" => %{"type" => "name", "properties" => %{"name" => "EPSG:4326"}}
+      }
+
+      result = Geometry.cast(point_map)
+
+      assert {:ok, point} = result
+      assert %Geo.Point{} = point
+      assert point.coordinates == {30.0, -90.0}
+      assert point.srid == 4326
+    end
+
+    test "cast from map with key: value syntax" do
+      point_map = %{
+        type: "Point",
+        coordinates: [30.0, -90.0],
+        crs: %{type: "name", properties: %{name: "EPSG:4326"}}
+      }
+
+      result = Geometry.cast(point_map)
+
+      assert {:ok, point} = result
+      assert %Geo.Point{} = point
+      assert point.coordinates == {30.0, -90.0}
+      assert point.srid == 4326
+    end
+  end
+end

--- a/test/geometry_test.exs
+++ b/test/geometry_test.exs
@@ -32,5 +32,57 @@ defmodule Geo.PostGIS.GeometryCastTest do
       assert point.coordinates == {30.0, -90.0}
       assert point.srid == 4326
     end
+
+    test "cast GeometryCollection from map with key => value syntax" do
+      collection_map = %{
+        "type" => "GeometryCollection",
+        "geometries" => [
+          %{
+            "type" => "Point",
+            "coordinates" => [30.0, -90.0]
+          },
+          %{
+            "type" => "LineString",
+            "coordinates" => [[30.0, -30.0], [90.0, -90.0]]
+          }
+        ],
+        "crs" => %{"type" => "name", "properties" => %{"name" => "EPSG:4326"}}
+      }
+
+      result = Geometry.cast(collection_map)
+
+      assert {:ok, collection} = result
+      assert %Geo.GeometryCollection{} = collection
+      assert length(collection.geometries) == 2
+      assert Enum.at(collection.geometries, 0).__struct__ == Geo.Point
+      assert Enum.at(collection.geometries, 1).__struct__ == Geo.LineString
+      assert collection.srid == 4326
+    end
+
+    test "cast GeometryCollection from map with key: value syntax" do
+      collection_map = %{
+        type: "GeometryCollection",
+        geometries: [
+          %{
+            type: "Point",
+            coordinates: [30.0, -90.0]
+          },
+          %{
+            type: "LineString",
+            coordinates: [[30.0, -30.0], [90.0, -90.0]]
+          }
+        ],
+        crs: %{type: "name", properties: %{name: "EPSG:4326"}}
+      }
+
+      result = Geometry.cast(collection_map)
+
+      assert {:ok, collection} = result
+      assert %Geo.GeometryCollection{} = collection
+      assert length(collection.geometries) == 2
+      assert Enum.at(collection.geometries, 0).__struct__ == Geo.Point
+      assert Enum.at(collection.geometries, 1).__struct__ == Geo.LineString
+      assert collection.srid == 4326
+    end
   end
 end


### PR DESCRIPTION
No `cast/1` function clauses were matching with an atom-keyed map as input. The string-keyed versions do not match even though they look similar.

These changes add in the atom-keyed clauses and some related tests. It should resolve this issue: https://github.com/felt/geo_postgis/issues/213

I used the JSON encoding/decoding process to handle nesting structures easily and minimize extra code. This extra conversion step could be removed if atom-keyed lookup for keys is added to the underlying JSON library. As this library is configurable in `geo_postgis`, not all JSON libraries will necessarily support the atom-keyed syntax. So encoding to decode is generally more usable.

If most JSON libraries _do_ support that syntax though, then I would gladly add this update to those libraries. :smile: Is anyone familiar with this?