### PR TITLE
Add more linear referencing macros

### DIFF
--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -481,4 +481,14 @@ defmodule Geo.PostGIS do
   defmacro st_line_locate_point(lineGeometry, pointGeometry) do
     quote do: fragment("ST_LineLocatePoint(?, ?)", unquote(lineGeometry), unquote(pointGeometry))
   end
+
+  defmacro st_line_substring(geometry, startFraction, endFraction) do
+    quote do:
+            fragment(
+              "ST_LineSubstring(?, ?, ?)",
+              unquote(geometry),
+              unquote(startFraction),
+              unquote(endFraction)
+            )
+  end
 end


### PR DESCRIPTION
Add `st_line_locate_point` and `st_line_substring`

https://postgis.net/docs/ST_LineLocatePoint.html
https://postgis.net/docs/ST_LineSubstring.html