### PR TITLE
Update PostGIS reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ defmodule MyApp.Repo.Migrations.EnablePostgis do
 end
 ```
 
-[PostGIS functions](http://postgis.net/docs/manual-1.3/ch06.html) can also be used in Ecto queries. Currently only the OpenGIS functions are implemented. Have a look at [lib/geo_postgis.ex](lib/geo_postgis.ex) for the implemented functions. You can use them like:
+[PostGIS functions](https://postgis.net/docs/reference.html) can also be used in Ecto queries. Currently only the OpenGIS functions are implemented. Have a look at [lib/geo_postgis.ex](lib/geo_postgis.ex) for the implemented functions. You can use them like:
 
 ```elixir
 defmodule Example do

--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -1,7 +1,7 @@
 defmodule Geo.PostGIS do
   @moduledoc """
   PostGIS functions that can used in ecto queries
-  [PostGIS Function Documentation](http://postgis.net/docs/manual-1.3/ch06.html).
+  [PostGIS Function Documentation](https://postgis.net/docs/reference.html).
 
   Currently only the OpenGIS functions are implemented.
 


### PR DESCRIPTION
See title! :zap:

Do we target any specific versions of PostGIS for support?

The previous links were for PostGIS [1.3.6](http://postgis.net/docs/manual-1.3/apa.html#id443574) which was released back on 2009-05-04 and PostGIS is now up to [3.5](https://trac.osgeo.org/postgis/wiki/UsersWikiPostgreSQLPostGIS). I've been using 3.4.3 for some projects and updates to this repository.

And is there a standard place for discussions for this project outside of PRs or Issues?