### PR TITLE
Resolve internal type error in failing tests

### DIFF
--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -880,7 +880,7 @@ defmodule Geo.Ecto.Test do
       query =
         from(l in LocationMulti,
           where: l.name == "collection",
-          select: st_is_collection(l.geom)
+          select: st_is_collection(st_make_valid(l.geom))
         )
 
       result = Repo.one(query)


### PR DESCRIPTION
The newer version of GEOS in the test workflow appears to be more strict about the internal representation of collection geometries and two tests were failing.

Adding a `st_make_valid` step resolves this issue. I'm proceeding on to determine if something more fundamental can be updated.