### PR TITLE
Add point constructor macros

### DIFF
--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -259,6 +259,14 @@ defmodule Geo.PostGIS do
     quote do: fragment("ST_Point(?, ?)", unquote(x), unquote(y))
   end
 
+  defmacro st_point_z(x, y, z) do
+    quote do: fragment("ST_PointZ(?, ?, ?)", unquote(x), unquote(y), unquote(z))
+  end
+
+  defmacro st_point_z(x, y, z, srid) do
+    quote do: fragment("ST_PointZ(?, ?, ?, ?)", unquote(x), unquote(y), unquote(z), unquote(srid))
+  end
+
   defmacro st_exterior_ring(geometry) do
     quote do: fragment("ST_ExteriorRing(?)", unquote(geometry))
   end

--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -282,6 +282,22 @@ defmodule Geo.PostGIS do
     quote do: fragment("ST_PointM(?, ?, ?, ?)", unquote(x), unquote(y), unquote(m), unquote(srid))
   end
 
+  defmacro st_point_zm(x, y, z, m) do
+    quote do: fragment("ST_PointZM(?, ?, ?, ?)", unquote(x), unquote(y), unquote(z), unquote(m))
+  end
+
+  defmacro st_point_zm(x, y, z, m, srid) do
+    quote do:
+            fragment(
+              "ST_PointZM(?, ?, ?, ?, ?)",
+              unquote(x),
+              unquote(y),
+              unquote(z),
+              unquote(m),
+              unquote(srid)
+            )
+  end
+
   defmacro st_exterior_ring(geometry) do
     quote do: fragment("ST_ExteriorRing(?)", unquote(geometry))
   end

--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -267,6 +267,14 @@ defmodule Geo.PostGIS do
     quote do: fragment("ST_PointZ(?, ?, ?, ?)::geometry", unquote(x), unquote(y), unquote(z), unquote(srid))
   end
 
+  defmacro st_point_m(x, y, m) do
+    quote do: fragment("ST_PointM(?, ?, ?)", unquote(x), unquote(y), unquote(m))
+  end
+
+  defmacro st_point_m(x, y, m, srid) do
+    quote do: fragment("ST_PointM(?, ?, ?, ?)", unquote(x), unquote(y), unquote(m), unquote(srid))
+  end
+
   defmacro st_exterior_ring(geometry) do
     quote do: fragment("ST_ExteriorRing(?)", unquote(geometry))
   end

--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -264,7 +264,14 @@ defmodule Geo.PostGIS do
   end
 
   defmacro st_point_z(x, y, z, srid) do
-    quote do: fragment("ST_PointZ(?, ?, ?, ?)::geometry", unquote(x), unquote(y), unquote(z), unquote(srid))
+    quote do:
+            fragment(
+              "ST_PointZ(?, ?, ?, ?)::geometry",
+              unquote(x),
+              unquote(y),
+              unquote(z),
+              unquote(srid)
+            )
   end
 
   defmacro st_point_m(x, y, m) do

--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -260,11 +260,11 @@ defmodule Geo.PostGIS do
   end
 
   defmacro st_point_z(x, y, z) do
-    quote do: fragment("ST_PointZ(?, ?, ?)", unquote(x), unquote(y), unquote(z))
+    quote do: fragment("ST_PointZ(?, ?, ?)::geometry", unquote(x), unquote(y), unquote(z))
   end
 
   defmacro st_point_z(x, y, z, srid) do
-    quote do: fragment("ST_PointZ(?, ?, ?, ?)", unquote(x), unquote(y), unquote(z), unquote(srid))
+    quote do: fragment("ST_PointZ(?, ?, ?, ?)::geometry", unquote(x), unquote(y), unquote(z), unquote(srid))
   end
 
   defmacro st_exterior_ring(geometry) do

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -1005,4 +1005,24 @@ defmodule Geo.Ecto.Test do
       assert MapSet.new(polygon_coords) == MapSet.new(result.coordinates)
     end
   end
+
+  describe "st_point_z/3 and st_point_z/4" do
+    test "creates a 3D point without SRID" do
+      query = from(l in LocationMulti, select: st_point_z(-71.104, 42.315, 3.4), limit: 1)
+
+      result = Repo.one(query)
+      assert %Geo.PointZ{} = result
+      assert result.coordinates == {-71.104, 42.315, 3.4}
+      assert result.srid == nil
+    end
+
+    test "creates a 3D point with SRID" do
+      query = from(l in LocationMulti, select: st_point_z(-71.104, 42.315, 3.4, 4326), limit: 1)
+
+      result = Repo.one(query)
+      assert %Geo.PointZ{} = result
+      assert result.coordinates == {-71.104, 42.315, 3.4}
+      assert result.srid == 4326
+    end
+  end
 end

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -1031,4 +1031,30 @@ defmodule Geo.Ecto.Test do
       assert result.srid == 4326
     end
   end
+
+  describe "st_point_m/3 and st_point_m/4" do
+    test "creates a point with M coordinate without SRID" do
+      point = %Geo.Point{coordinates: {0, 0}, srid: 4326}
+      Repo.insert(%LocationMulti{name: "empty", geom: point})
+
+      query = from(l in LocationMulti, select: st_point_m(-71.104, 42.315, 3.4), limit: 1)
+
+      result = Repo.one(query)
+      assert %Geo.PointM{} = result
+      assert result.coordinates == {-71.104, 42.315, 3.4}
+      assert result.srid == nil
+    end
+
+    test "creates a point with M coordinate with SRID" do
+      point = %Geo.Point{coordinates: {0, 0}, srid: 4326}
+      Repo.insert(%LocationMulti{name: "empty", geom: point})
+
+      query = from(l in LocationMulti, select: st_point_m(-71.104, 42.315, 3.4, 4326), limit: 1)
+
+      result = Repo.one(query)
+      assert %Geo.PointM{} = result
+      assert result.coordinates == {-71.104, 42.315, 3.4}
+      assert result.srid == 4326
+    end
+  end
 end

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -1008,6 +1008,9 @@ defmodule Geo.Ecto.Test do
 
   describe "st_point_z/3 and st_point_z/4" do
     test "creates a 3D point without SRID" do
+      point = %Geo.Point{coordinates: {0, 0}, srid: 4326}
+      Repo.insert(%LocationMulti{name: "empty", geom: point})
+
       query = from(l in LocationMulti, select: st_point_z(-71.104, 42.315, 3.4), limit: 1)
 
       result = Repo.one(query)
@@ -1017,6 +1020,9 @@ defmodule Geo.Ecto.Test do
     end
 
     test "creates a 3D point with SRID" do
+      point = %Geo.Point{coordinates: {0, 0}, srid: 4326}
+      Repo.insert(%LocationMulti{name: "empty", geom: point})
+
       query = from(l in LocationMulti, select: st_point_z(-71.104, 42.315, 3.4, 4326), limit: 1)
 
       result = Repo.one(query)

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -1057,4 +1057,31 @@ defmodule Geo.Ecto.Test do
       assert result.srid == 4326
     end
   end
+
+  describe "st_point_zm/4 and st_point_zm/5" do
+    test "creates a 4D point without SRID" do
+      point = %Geo.Point{coordinates: {0, 0}, srid: 4326}
+      Repo.insert(%LocationMulti{name: "empty", geom: point})
+
+      query = from(l in LocationMulti, select: st_point_zm(-71.104, 42.315, 3.4, 4.5), limit: 1)
+
+      result = Repo.one(query)
+      assert %Geo.PointZM{} = result
+      assert result.coordinates == {-71.104, 42.315, 3.4, 4.5}
+      assert result.srid == nil
+    end
+
+    test "creates a 4D point with SRID" do
+      point = %Geo.Point{coordinates: {0, 0}, srid: 4326}
+      Repo.insert(%LocationMulti{name: "empty", geom: point})
+
+      query =
+        from(l in LocationMulti, select: st_point_zm(-71.104, 42.315, 3.4, 4.5, 4326), limit: 1)
+
+      result = Repo.one(query)
+      assert %Geo.PointZM{} = result
+      assert result.coordinates == {-71.104, 42.315, 3.4, 4.5}
+      assert result.srid == 4326
+    end
+  end
 end


### PR DESCRIPTION
Add `st_point_z/3`, `st_point_z/4`, `st_point_m/3`, `st_point_m/4`, `st_point_zm/4` and `st_point_zm/5`

https://postgis.net/docs/manual-3.7/ST_PointZ.html
https://postgis.net/docs/manual-3.7/ST_PointM.html
https://postgis.net/docs/manual-3.7/ST_PointZM.html