### PR TITLE
Add ST_DWithin/4 macros and Ecto integration tests

### DIFF
--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -57,6 +57,22 @@ defmodule Geo.PostGIS do
   end
 
   @doc """
+  Geography form of `ST_DWithin/4`: distance is in meters; `use_spheroid` is forwarded to PostGIS.
+
+  See [ST_DWithin](https://postgis.net/docs/ST_DWithin.html).
+  """
+  defmacro st_dwithin(geometryA, geometryB, float, use_spheroid) do
+    quote do:
+            fragment(
+              "ST_DWithin(?,?,?,?)",
+              unquote(geometryA),
+              unquote(geometryB),
+              unquote(float),
+              unquote(use_spheroid)
+            )
+  end
+
+  @doc """
   Casts the 2 geometries given to geographies in order to check for distance in meters.
   """
   defmacro st_dwithin_in_meters(geometryA, geometryB, float) do
@@ -66,6 +82,22 @@ defmodule Geo.PostGIS do
               unquote(geometryA),
               unquote(geometryB),
               unquote(float)
+            )
+  end
+
+  @doc """
+  Like `st_dwithin_in_meters/3` but passes `use_spheroid` to PostGIS.
+
+  See [ST_DWithin](https://postgis.net/docs/ST_DWithin.html).
+  """
+  defmacro st_dwithin_in_meters(geometryA, geometryB, float, use_spheroid) do
+    quote do:
+            fragment(
+              "ST_DWithin(?::geography, ?::geography, ?, ?)",
+              unquote(geometryA),
+              unquote(geometryB),
+              unquote(float),
+              unquote(use_spheroid)
             )
   end
 

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -222,6 +222,58 @@ defmodule Geo.Ecto.Test do
              |> Enum.map(fn x -> x.name end)
   end
 
+  describe "st_dwithin/4 and st_dwithin_in_meters/4" do
+    test "st_dwithin/4 with geography operands and use_spheroid" do
+      here = %Geo.Point{coordinates: {30, -90}, srid: 4326}
+      there = %Geo.Point{coordinates: {30, -91}, srid: 4326}
+
+      Repo.insert(%Geographies{name: "here", geom: here})
+
+      within =
+        from(
+          g in Geographies,
+          where: g.name == "here",
+          select: st_dwithin(g.geom, ^there, 150_000, true)
+        )
+
+      assert Repo.one(within) == true
+
+      not_within =
+        from(
+          g in Geographies,
+          where: g.name == "here",
+          select: st_dwithin(g.geom, ^there, 100_000, true)
+        )
+
+      assert Repo.one(not_within) == false
+    end
+
+    test "st_dwithin_in_meters/4 casts to geography and passes use_spheroid" do
+      here = %Geo.Point{coordinates: {30, -90}, srid: 4326}
+      there = %Geo.Point{coordinates: {30, -91}, srid: 4326}
+
+      Repo.insert(%LocationMulti{name: "dwithin_a", geom: here})
+
+      within =
+        from(
+          l in LocationMulti,
+          where: l.name == "dwithin_a",
+          select: st_dwithin_in_meters(l.geom, ^there, 150_000, false)
+        )
+
+      assert Repo.one(within) == true
+
+      not_within =
+        from(
+          l in LocationMulti,
+          where: l.name == "dwithin_a",
+          select: st_dwithin_in_meters(l.geom, ^there, 100_000, false)
+        )
+
+      assert Repo.one(not_within) == false
+    end
+  end
+
   test "insert multiple geometry types" do
     geom1 = %Geo.Point{coordinates: {30, -90}, srid: 4326}
     geom2 = %Geo.LineString{coordinates: [{30, -90}, {30, -91}], srid: 4326}


### PR DESCRIPTION
Expose `st_dwithin/4` and `st_dwithin_in_meters/4` for geography distance checks with `use_spheroid`.